### PR TITLE
tweak messages and change pin check order

### DIFF
--- a/lib/freshest-pot.rb
+++ b/lib/freshest-pot.rb
@@ -4,6 +4,7 @@ require 'sonos'
 require 'curb'
 include PiPiper
 
+brewing = false
 # Initialize audio announcements
 audio = []
 audio_index = 0
@@ -18,9 +19,16 @@ system = Sonos::System.new
 speaker = system.speakers.first
 
 after :pin => 4, :goes => :high do
-  speaker.play 'http://127.0.0.1/' + audio[audio_index]
-  Curl.post('https://hooks.slack.com/services/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', {:payload => 'payload={"text": "/giphy FRESH POTS"}'})
-  audio_index = (audio_index + 1) % audio.length
+  Curl.post('https://hooks.slack.com/services/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', {:payload => 'payload={"text": "Something\'s brewing ..."}'})
+  brewing = true
+end
+after :pin => 4, :goes => :low do
+  if brewing
+    brewing = false
+    speaker.play 'http://127.0.0.1/' + audio[audio_index]
+    Curl.post('https://hooks.slack.com/services/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', {:payload => 'payload={"text": "/giphy FRESH POTS"}'})
+    audio_index = (audio_index + 1) % audio.length
+  end
 end
 
 PiPiper.wait


### PR DESCRIPTION
If we're attaching to the LED - which it sounds like we'll be doing - then we should change the message ordering to reflect what happens when the LED's on/off.

> LED goes on -> brew cycle is starting
> LED goes off -> brew complete

I've put a message in there to say that something's brewing when the button's pushed. In the future, we can use this in concert with the scale to determine estimated time to completion.

In order to prevent an inadvertent pin goes low when the script fires up (not sure if that would actually happen or not) - I added a flag variable to keep track of whether we're currently brewing. Perhaps this could be used in concert with a web service to determine estimated time to brew completion when that's implemented ...
